### PR TITLE
Add LM Studio provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ To do so, you must first define custom [providers](./config.md#model_providers) 
 [model_providers.ollama]
 name = "Ollama"
 base_url = "http://localhost:11434/v1"
+
+[model_providers.lm-studio]
+name = "LM Studio"
+base_url = "http://localhost:1234/v1"
 ```
 
 The `base_url` will have `/chat/completions` appended to it to build the full URL for the request.

--- a/codex-cli/README.md
+++ b/codex-cli/README.md
@@ -104,6 +104,7 @@ export OPENAI_API_KEY="your-api-key-here"
 > - azure
 > - gemini
 > - ollama
+> - lm-studio
 > - mistral
 > - deepseek
 > - xai
@@ -418,6 +419,11 @@ Below is a comprehensive example of `config.json` with multiple custom providers
       "name": "Ollama",
       "baseURL": "http://localhost:11434/v1",
       "envKey": "OLLAMA_API_KEY"
+    },
+    "lm-studio": {
+      "name": "LM Studio",
+      "baseURL": "http://localhost:1234/v1",
+      "envKey": "LM_STUDIO_API_KEY"
     },
     "mistral": {
       "name": "Mistral",

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -382,7 +382,7 @@ if (cli.flags.free && provider.toLowerCase() === "openai") {
 }
 
 // Set of providers that don't require API keys
-const NO_API_KEY_REQUIRED = new Set(["ollama"]);
+const NO_API_KEY_REQUIRED = new Set(["ollama", "lm-studio"]);
 
 // Skip API key validation for providers that don't require an API key
 if (!apiKey && !NO_API_KEY_REQUIRED.has(provider.toLowerCase())) {

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -52,4 +52,9 @@ export const providers: Record<
     baseURL: "https://conductor.arcee.ai/v1",
     envKey: "ARCEEAI_API_KEY",
   },
+  "lm-studio": {
+    name: "LM Studio",
+    baseURL: "http://localhost:1234/v1",
+    envKey: "LM_STUDIO_API_KEY",
+  },
 };

--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -56,6 +56,14 @@ name = "Ollama"
 base_url = "http://localhost:11434/v1"
 ```
 
+Or if you are using LM Studio locally:
+
+```toml
+[model_providers.lm-studio]
+name = "LM Studio"
+base_url = "http://localhost:1234/v1"
+```
+
 Or a third-party provider (using a distinct environment variable for the API key):
 
 ```toml


### PR DESCRIPTION
## Summary
- add LM Studio provider info and sample config
- update README and config docs
- add LM Studio to CLI provider list
- skip API key requirement for LM Studio

## Testing
- `pnpm -r lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*
- `pnpm -r test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_687ce9db328083289b2bc089efbdd73f