### PR TITLE
Add web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This is the home of the **Codex CLI**, which is a coding agent from OpenAI that 
 - [Quickstart](#quickstart)
   - [OpenAI API Users](#openai-api-users)
   - [OpenAI Plus/Pro Users](#openai-pluspro-users)
+- [Web UI](#web-ui)
 - [Why Codex?](#why-codex)
 - [Security model & permissions](#security-model--permissions)
   - [Platform sandboxing details](#platform-sandboxing-details)
@@ -177,6 +178,18 @@ codex --full-auto "create the fanciest todo-list app"
 That's it - Codex will scaffold a file, run it inside a sandbox, install any
 missing dependencies, and show you the live result. Approve the changes and
 they'll be committed to your working directory.
+
+---
+
+## Web UI
+
+For a browser-based experience, you can run the new Web UI package:
+
+```bash
+pnpm --filter @openai/codex-web run dev
+```
+
+This starts a development server at `http://localhost:5173`.
 
 ---
 

--- a/packages/codex-web/README.md
+++ b/packages/codex-web/README.md
@@ -1,0 +1,16 @@
+# Codex Web UI
+
+A simple web interface for running Codex commands.
+
+## Development
+
+```bash
+pnpm --filter @openai/codex-web install
+pnpm --filter @openai/codex-web run dev
+```
+
+## Build
+
+```bash
+pnpm --filter @openai/codex-web run build
+```

--- a/packages/codex-web/index.html
+++ b/packages/codex-web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Codex Web UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/codex-web/package.json
+++ b/packages/codex-web/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@openai/codex-web",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "start": "ts-node server.ts"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/material": "^5.15.17",
+    "express": "^5.1.0",
+    "body-parser": "^1.20.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.18",
+    "typescript": "^5.4.5",
+    "vite": "^6.3.4",
+    "@vitejs/plugin-react": "^4.2.1",
+    "ts-node": "^10.9.1"
+  }
+}

--- a/packages/codex-web/server.ts
+++ b/packages/codex-web/server.ts
@@ -1,0 +1,28 @@
+import express from 'express';
+import { exec } from 'child_process';
+import { json } from 'body-parser';
+
+const app = express();
+app.use(json());
+
+app.post('/api/run', (req, res) => {
+  const { command } = req.body as { command: string };
+  if (!command) {
+    res.status(400).json({ error: 'Missing command' });
+    return;
+  }
+  exec(`codex ${command}`, { cwd: process.cwd() }, (err, stdout, stderr) => {
+    if (err) {
+      res.json({ output: stderr });
+    } else {
+      res.json({ output: stdout });
+    }
+  });
+});
+
+app.use(express.static('.'));
+
+const port = 3000;
+app.listen(port, () => {
+  console.log(`Codex Web UI running at http://localhost:${port}`);
+});

--- a/packages/codex-web/src/App.tsx
+++ b/packages/codex-web/src/App.tsx
@@ -1,0 +1,46 @@
+import { Box, Button, Container, TextField, Typography } from '@mui/material';
+import { useState } from 'react';
+
+export default function App() {
+  const [command, setCommand] = useState('');
+  const [output, setOutput] = useState('');
+
+  async function runCommand() {
+    const res = await fetch('/api/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command }),
+    });
+    const data = await res.json();
+    setOutput(data.output);
+  }
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Codex Web UI
+      </Typography>
+      <Box display="flex" gap={2}>
+        <TextField
+          fullWidth
+          label="Codex command"
+          value={command}
+          onChange={(e) => setCommand(e.target.value)}
+        />
+        <Button variant="contained" onClick={runCommand}>
+          Run
+        </Button>
+      </Box>
+      <Box mt={4}>
+        <Typography variant="h6">Output</Typography>
+        <Box
+          component="pre"
+          p={2}
+          sx={{ backgroundColor: '#f5f5f5', borderRadius: 1 }}
+        >
+          {output}
+        </Box>
+      </Box>
+    </Container>
+  );
+}

--- a/packages/codex-web/src/main.tsx
+++ b/packages/codex-web/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/packages/codex-web/tsconfig.json
+++ b/packages/codex-web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/packages/codex-web/vite.config.ts
+++ b/packages/codex-web/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- add simple Vite/React frontend in `packages/codex-web`
- document the web UI option in the README

## Testing
- `pnpm install` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_687cea275584832887592e5930cca1af